### PR TITLE
DEVOPS-697 THIS REPO IS DEPRECATED

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# DEPRECATED, migrated to statuspage.io, http://status.rounds.com
+
 [![nodesource/node](http://dockeri.co/image/rounds/cachethq-docker)](https://hub.docker.com/r/rounds/cachethq-docker/)
 
 Run [Cachet](https://github.com/cachethq/Cachet) status page in a Docker container.


### PR DESCRIPTION
we've moved to a managed http://statuspage.io
on http://status.rounds.com